### PR TITLE
Moving Demos to "Demos 2015" parent page

### DIFF
--- a/Vimeo.rb
+++ b/Vimeo.rb
@@ -87,7 +87,7 @@ def sort_event_parent(name)
   when "Big Picture"
     name_parent = "Big Picture"
   when "Demos"
-    name_parent = "Demos 2014"
+    name_parent = "Demos 2015"
   when "Design Review"
     name_parent = "Design Review"
   when "Misc"


### PR DESCRIPTION
Currently demos videos are going to the "Demos 2014" page, but it is no longer 2014. I have changed the name of the parent page in the uploader script and created a "Demos 2015" page on confluence that demos videos will now go to.
